### PR TITLE
feat(WrapHandler): add config using functional options

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -25,10 +25,8 @@ import (
 func main() {
 	r := gin.New()
 
-	config := &ginSwagger.Config{
-		URL: "http://localhost:8080/swagger/doc.json", //The url pointing to API definition
-	}
-	r.GET("/swagger/*any", ginSwagger.CustomWrapHandler(config, swaggerFiles.Handler))
+	url := ginSwagger.URL("http://localhost:8080/swagger/doc.json") //The url pointing to API definition
+	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, url))
 
 	r.Run()
 }

--- a/swagger.go
+++ b/swagger.go
@@ -13,16 +13,27 @@ import (
 
 // Config stores ginSwagger configuration variables.
 type Config struct {
-	//The url pointing to API definition (normally swagger.json or swagger.yaml).
+	//The url pointing to API definition (normally swagger.json or swagger.yaml). Default is doc.json
 	URL string
 }
 
-var defaultConfig = &Config{
-	URL: "http://localhost:8080/swagger/doc.json", //The url pointing to API definition
+// URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
+func URL(url string) func(c *Config) {
+	return func(c *Config) {
+		c.URL = url
+	}
 }
 
 // WrapHandler wraps `http.Handler` into `gin.HandlerFunc`.
-func WrapHandler(h *webdav.Handler) gin.HandlerFunc {
+func WrapHandler(h *webdav.Handler, confs ...func(c *Config)) gin.HandlerFunc {
+	defaultConfig := &Config{
+		URL: "doc.json",
+	}
+
+	for _, c := range confs {
+		c(defaultConfig)
+	}
+
 	return CustomWrapHandler(defaultConfig, h)
 }
 

--- a/swagger.go
+++ b/swagger.go
@@ -13,7 +13,7 @@ import (
 
 // Config stores ginSwagger configuration variables.
 type Config struct {
-	//The url pointing to API definition (normally swagger.json or swagger.yaml). Default is doc.json
+	//The url pointing to API definition (normally swagger.json or swagger.yaml). Default is `doc.json`.
 	URL string
 }
 


### PR DESCRIPTION
-  [functional options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis)
-  undo default URL config to `doc.json`


