### PR TITLE
Solve the problem of Chinese garbled with integrated swagger to gin framework

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -69,7 +69,7 @@ func CustomWrapHandler(config *Config, h *webdav.Handler) gin.HandlerFunc {
 		} else if strings.HasSuffix(path, ".js") {
 			c.Header("Content-Type", "application/javascript")
 		} else if strings.HasSuffix(path, ".json") {
-			c.Header("Content-Type", "application/json")
+			c.Header("Content-Type", "application/json; charset=utf-8")
 		}
 
 		switch path {

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -120,7 +120,7 @@ func TestWithGzipMiddleware(t *testing.T) {
 
 	w4 := performRequest("GET", "/doc.json", router)
 	assert.Equal(t, 200, w4.Code)
-	assert.Equal(t, w4.Header()["Content-Type"][0], "application/json")
+	assert.Equal(t, w4.Header()["Content-Type"][0], "application/json; charset=utf-8")
 }
 
 func performRequest(method, target string, router *gin.Engine) *httptest.ResponseRecorder {


### PR DESCRIPTION
Solve the integration swagger into the gin framework, access the Chinese garbled problem in the json returned by swagger/doc.json.