### PR TITLE
feat: implement deeplinking

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -15,7 +15,8 @@ import (
 // Config stores ginSwagger configuration variables.
 type Config struct {
 	//The url pointing to API definition (normally swagger.json or swagger.yaml). Default is `doc.json`.
-	URL string
+	URL         string
+	DeepLinking bool
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -25,10 +26,18 @@ func URL(url string) func(c *Config) {
 	}
 }
 
+// DeepLinking set the swagger deeplinking configuration
+func DeepLinking(deepLinking bool) func(c *Config) {
+	return func(c *Config) {
+		c.DeepLinking = deepLinking
+	}
+}
+
 // WrapHandler wraps `http.Handler` into `gin.HandlerFunc`.
 func WrapHandler(h *webdav.Handler, confs ...func(c *Config)) gin.HandlerFunc {
 	defaultConfig := &Config{
-		URL: "doc.json",
+		URL:         "doc.json",
+		DeepLinking: true,
 	}
 
 	for _, c := range confs {
@@ -49,7 +58,8 @@ func CustomWrapHandler(config *Config, h *webdav.Handler) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
 		type swaggerUIBundle struct {
-			URL string
+			URL         string
+			DeepLinking bool
 		}
 
 		var matches []string
@@ -75,7 +85,8 @@ func CustomWrapHandler(config *Config, h *webdav.Handler) gin.HandlerFunc {
 		switch path {
 		case "index.html":
 			index.Execute(c.Writer, &swaggerUIBundle{
-				URL: config.URL,
+				URL:         config.URL,
+				DeepLinking: config.DeepLinking,
 			})
 		case "doc.json":
 			doc, err := swag.ReadDoc()
@@ -205,7 +216,8 @@ window.onload = function() {
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-    layout: "StandaloneLayout"
+	layout: "StandaloneLayout",
+	deepLinking: {{.DeepLinking}}
   })
 
   window.ui = ui


### PR DESCRIPTION
Hi, beginner here...
Already implement gin swagger in our project and we need [deepLinking](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/deep-linking.md) feature to make docs sharing easier.
I thought it would be better to make deepLinking enabled by default.