### PR TITLE
support self define swagger.json mount url

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -88,7 +88,7 @@ func CustomWrapHandler(config *Config, h *webdav.Handler) gin.HandlerFunc {
 				URL:         config.URL,
 				DeepLinking: config.DeepLinking,
 			})
-		case "doc.json":
+		case config.URL:
 			doc, err := swag.ReadDoc()
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
Update swagger.go to support self define swagger.json mount url.
now the default url is doc.json, and hard code switch case doc.json