### PR TITLE
feat(ui): configure default expansion depth for models

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,25 @@ Demo project tree, `swag init` is run at relative `.`
 ├── go.sum
 └── main.go
 ```
+
+## Configuration
+
+You can configure Swagger using different configuration options
+
+```go
+func main() {
+	r := gin.New()
+
+	ginSwagger.WrapHandler(swaggerFiles.Handler, 
+		ginSwagger.URL("http://localhost:8080/swagger/doc.json"), 
+		ginSwagger.DefaultModelsExpandDepth(-1)))
+
+	r.Run()
+}
+```
+
+| Option                   | Type   | Default    | Description                                                               |
+|--------------------------|--------|------------|---------------------------------------------------------------------------|
+| URL                      | string | "doc.json" | URL pointing to API definition                                            |
+| DeepLinking              | bool   | true       | Swagger deeplinking configuration                                         |
+| DefaultModelsExpandDepth | int    | 1          | Default expansion depth for models (set to -1 completely hide the models) |

--- a/swagger.go
+++ b/swagger.go
@@ -17,8 +17,9 @@ import (
 // Config stores ginSwagger configuration variables.
 type Config struct {
 	//The url pointing to API definition (normally swagger.json or swagger.yaml). Default is `doc.json`.
-	URL         string
-	DeepLinking bool
+	URL                      string
+	DeepLinking              bool
+	DefaultModelsExpandDepth int
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -35,11 +36,20 @@ func DeepLinking(deepLinking bool) func(c *Config) {
 	}
 }
 
+// DefaultModelsExpandDepth set the default expansion depth for models
+// (set to -1 completely hide the models).
+func DefaultModelsExpandDepth(depth int) func(c *Config) {
+	return func(c *Config) {
+		c.DefaultModelsExpandDepth = depth
+	}
+}
+
 // WrapHandler wraps `http.Handler` into `gin.HandlerFunc`.
 func WrapHandler(h *webdav.Handler, confs ...func(c *Config)) gin.HandlerFunc {
 	defaultConfig := &Config{
-		URL:         "doc.json",
-		DeepLinking: true,
+		URL:                      "doc.json",
+		DeepLinking:              true,
+		DefaultModelsExpandDepth: 1,
 	}
 
 	for _, c := range confs {
@@ -61,8 +71,9 @@ func CustomWrapHandler(config *Config, h *webdav.Handler) gin.HandlerFunc {
 	return func(c *gin.Context) {
 
 		type swaggerUIBundle struct {
-			URL         string
-			DeepLinking bool
+			URL                      string
+			DeepLinking              bool
+			DefaultModelsExpandDepth int
 		}
 
 		var matches []string
@@ -91,8 +102,9 @@ func CustomWrapHandler(config *Config, h *webdav.Handler) gin.HandlerFunc {
 		switch path {
 		case "index.html":
 			index.Execute(c.Writer, &swaggerUIBundle{
-				URL:         config.URL,
-				DeepLinking: config.DeepLinking,
+				URL:                      config.URL,
+				DeepLinking:              config.DeepLinking,
+				DefaultModelsExpandDepth: config.DefaultModelsExpandDepth,
 			})
 		case "doc.json":
 			doc, err := swag.ReadDoc()
@@ -226,7 +238,8 @@ window.onload = function() {
       SwaggerUIBundle.plugins.DownloadUrl
     ],
 	layout: "StandaloneLayout",
-	deepLinking: {{.DeepLinking}}
+	deepLinking: {{.DeepLinking}},
+	defaultModelsExpandDepth: {{.DefaultModelsExpandDepth}}
   })
 
   window.ui = ui

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -157,3 +157,11 @@ func TestDeepLinking(t *testing.T) {
 	configFunc(&cfg)
 	assert.Equal(t, expected, cfg.DeepLinking)
 }
+
+func TestDefaultModelsExpandDepth(t *testing.T) {
+	expected := -1
+	cfg := Config{}
+	configFunc := DefaultModelsExpandDepth(expected)
+	configFunc(&cfg)
+	assert.Equal(t, expected, cfg.DefaultModelsExpandDepth)
+}


### PR DESCRIPTION
This PR adds possibility to configure `defaultModelsExpandDepth`, which controls how models (at the bottom of the API doc) are displayed.

Default value is 1, but it can be set to -1 completely hide the models.

More information about it:
https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#display
https://stackoverflow.com/questions/57138564/how-to-hide-the-models-section-in-swagger-ui