### PR TITLE
Allows instance names to be configured

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -21,6 +21,7 @@ type Config struct {
 	DeepLinking              bool
 	DocExpansion             string
 	DefaultModelsExpandDepth int
+	InstanceName             string
 }
 
 // URL presents the url pointing to API definition (normally swagger.json or swagger.yaml).
@@ -109,7 +110,7 @@ func CustomWrapHandler(config *Config, handler *webdav.Handler) gin.HandlerFunc 
 		case "index.html":
 			_ = index.Execute(c.Writer, config)
 		case "doc.json":
-			doc, err := swag.ReadDoc()
+			doc, err := swag.ReadDoc(config.InstanceName)
 			if err != nil {
 				c.AbortWithStatus(http.StatusInternalServerError)
 


### PR DESCRIPTION
**Describe the PR**
Allows instance names to be configured

**Relation issue**
[swaggo/swag#1022](https://github.com/swaggo/swag/pull/1022)

**Additional context**
When there are multiple Swagger documents, you need to be able to specify the instance name.
e. g.  
`swag.Register("v1", &s{})`
```
r.GET("/swagger/v1/*any", ginSwagger.WrapHandler(swaggerFiles.Handler, func(c *ginSwagger.Config) {
    c.InstanceName = "v1"
}))
```
