### PR TITLE
Removed Once condition for setting prefix

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sync"
 
 	"golang.org/x/net/webdav"
 
@@ -118,7 +117,6 @@ func WrapHandler(h *webdav.Handler, confs ...func(c *Config)) gin.HandlerFunc {
 
 // CustomWrapHandler wraps `http.Handler` into `gin.HandlerFunc`
 func CustomWrapHandler(config *Config, handler *webdav.Handler) gin.HandlerFunc {
-	var once sync.Once
 
 	if config.InstanceName == "" {
 		config.InstanceName = swag.Name
@@ -143,9 +141,7 @@ func CustomWrapHandler(config *Config, handler *webdav.Handler) gin.HandlerFunc 
 		}
 
 		path := matches[2]
-		once.Do(func() {
-			handler.Prefix = matches[1]
-		})
+		handler.Prefix = matches[1]
 
 		switch filepath.Ext(path) {
 		case ".html":


### PR DESCRIPTION
- Solves 404 errors when handling more than one instance of Swagger in same server

**Describe the PR**
This changes allows to set the prefix on every request instead of once, this solves when you have more than one instance of Swagger in a server in a different path/prefix.

**Additional context**
I have two swagger instances, when I request one, the prefix is set by the first swagger handler, once you enter in the second instance of Swagger you get 404 because the prefix was set once.
