### PR TITLE
Add support for Swagger UI config param defaultModelExpandDepth

### DIFF
--- a/swagger.go
+++ b/swagger.go
@@ -20,6 +20,7 @@ type swaggerConfig struct {
 	Title                    string
 	Oauth2RedirectURL        template.JS
 	DefaultModelsExpandDepth int
+	DefaultModelExpandDepth  int
 	DeepLinking              bool
 	PersistAuthorization     bool
 	Oauth2DefaultClientID    string
@@ -33,6 +34,7 @@ type Config struct {
 	InstanceName             string
 	Title                    string
 	DefaultModelsExpandDepth int
+	DefaultModelExpandDepth  int
 	DeepLinking              bool
 	PersistAuthorization     bool
 	Oauth2DefaultClientID    string
@@ -44,6 +46,7 @@ func (config Config) toSwaggerConfig() swaggerConfig {
 		DeepLinking:              config.DeepLinking,
 		DocExpansion:             config.DocExpansion,
 		DefaultModelsExpandDepth: config.DefaultModelsExpandDepth,
+		DefaultModelExpandDepth:  config.DefaultModelExpandDepth,
 		Oauth2RedirectURL: "`${window.location.protocol}//${window.location.host}$" +
 			"{window.location.pathname.split('/').slice(0, window.location.pathname.split('/').length - 1).join('/')}" +
 			"/oauth2-redirect.html`",
@@ -82,6 +85,14 @@ func DefaultModelsExpandDepth(depth int) func(*Config) {
 	}
 }
 
+// DefaultModelsExpandDepth set the default expansion depth for the
+// model on the model-example section.
+func DefaultModelExpandDepth(depth int) func(*Config) {
+	return func(c *Config) {
+		c.DefaultModelExpandDepth = depth
+	}
+}
+
 // InstanceName set the instance name that was used to generate the swagger documents
 // Defaults to swag.Name ("swagger").
 func InstanceName(name string) func(*Config) {
@@ -113,6 +124,7 @@ func WrapHandler(handler *webdav.Handler, options ...func(*Config)) gin.HandlerF
 		InstanceName:             swag.Name,
 		Title:                    "Swagger UI",
 		DefaultModelsExpandDepth: 1,
+		DefaultModelExpandDepth:  1,
 		DeepLinking:              true,
 		PersistAuthorization:     false,
 		Oauth2DefaultClientID:    "",
@@ -307,10 +319,11 @@ window.onload = function() {
     plugins: [
       SwaggerUIBundle.plugins.DownloadUrl
     ],
-	layout: "StandaloneLayout",
+    layout: "StandaloneLayout",
     docExpansion: "{{.DocExpansion}}",
-	deepLinking: {{.DeepLinking}},
-	defaultModelsExpandDepth: {{.DefaultModelsExpandDepth}}
+    deepLinking: {{.DeepLinking}},
+    defaultModelsExpandDepth: {{.DefaultModelsExpandDepth}},
+    defaultModelExpandDepth: {{.DefaultModelExpandDepth}}
   })
 
   const defaultClientId = "{{.Oauth2DefaultClientID}}";

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -205,6 +205,22 @@ func TestDefaultModelsExpandDepth(t *testing.T) {
 	assert.Equal(t, expected, cfg.DefaultModelsExpandDepth)
 }
 
+func TestDefaultModelExpandDepth(t *testing.T) {
+	var cfg Config
+
+	assert.Equal(t, 0, cfg.DefaultModelExpandDepth)
+
+	expected := -1
+	configFunc := DefaultModelExpandDepth(expected)
+	configFunc(&cfg)
+	assert.Equal(t, expected, cfg.DefaultModelExpandDepth)
+
+	expected = 1
+	configFunc = DefaultModelExpandDepth(expected)
+	configFunc(&cfg)
+	assert.Equal(t, expected, cfg.DefaultModelExpandDepth)
+}
+
 func TestInstanceName(t *testing.T) {
 	var cfg Config
 


### PR DESCRIPTION
**Describe the PR**

Add support for the Swagger UI configutation parameter defaultModelExpandDepth
See https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/

**Relation issue**

None

**Additional context**

Support for the Swagger UI configutation parameter defaultModelsExpandDepth already exists but not for defaultModelExpandDepth (without s)
