### PR TITLE
Update ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,32 @@ Demo project tree, `swag init` is run at relative `.`
 ├── go.sum
 └── main.go
 ```
+## Project with Nested Directory
+```
+.
+├── cmd
+│   └── ginsimple
+│       └── main.go
+├── docs
+│   ├── docs.go
+│   ├── swagger.json
+│   └── swagger.yaml
+├── go.mod
+├── go.sum
+└── internal
+    ├── handlers
+    │   ├── helloWorld.go
+    │   └── userHandler.go
+    └── models
+        ├── profile.go
+        └── user.go
+```
+Inorder generate swagger docs for projects with nested directories run the following command
+```bash
+swag init -g ./cmd/ginsimple/main.go -o cmd/docs
+```
+`-o` will set the auto generated file to the specified path
+
 
 ## Multiple APIs
 


### PR DESCRIPTION
## No operations defined in spec!
**About the PR**

Swag cannot generate docs when `main.go` is located in a directory. Plainly running `swag init` will not parse subfolder for example ./internal or ./pkg directories

This simple update to ReadMe will resolve the following:

**Related issues**
#73 
#23 
#64 
#241 



