### PR TITLE
fix: return index.html for /swagger and /swagger/ instead of 404

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
       - name: test

--- a/swagger.go
+++ b/swagger.go
@@ -159,6 +159,12 @@ func CustomWrapHandler(config *Config, handler *webdav.Handler) gin.HandlerFunc 
 	var matcher = regexp.MustCompile(`(.*)(index\.html|index\.css|swagger-initializer\.js|doc\.json|favicon-16x16\.png|favicon-32x32\.png|/oauth2-redirect\.html|swagger-ui\.css|swagger-ui\.css\.map|swagger-ui\.js|swagger-ui\.js\.map|swagger-ui-bundle\.js|swagger-ui-bundle\.js\.map|swagger-ui-standalone-preset\.js|swagger-ui-standalone-preset\.js\.map)[?|.]*`)
 
 	return func(ctx *gin.Context) {
+		// Return index.html content for /swagger or /swagger/
+		if ctx.Request.Method == http.MethodGet && (ctx.Request.RequestURI == "/swagger" || ctx.Request.RequestURI == "/swagger/") {
+			ctx.Header("Content-Type", "text/html; charset=utf-8")
+			_ = index.Execute(ctx.Writer, config.toSwaggerConfig())
+			return
+		}
 		if ctx.Request.Method != http.MethodGet {
 			ctx.AbortWithStatus(http.StatusMethodNotAllowed)
 

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -80,6 +80,11 @@ func TestWrapCustomHandler(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, performRequest(http.MethodPost, "/index.html", router).Code)
 
 	assert.Equal(t, http.StatusMethodNotAllowed, performRequest(http.MethodPut, "/index.html", router).Code)
+
+	// Test: /swagger should redirect to /swagger/index.html (not implemented yet, should fail)
+	w := performRequest(http.MethodGet, "/swagger", router)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "<title>Swagger UI</title>")
 }
 
 func TestDisablingWrapHandler(t *testing.T) {

--- a/swagger_test.go
+++ b/swagger_test.go
@@ -85,6 +85,11 @@ func TestWrapCustomHandler(t *testing.T) {
 	w := performRequest(http.MethodGet, "/swagger", router)
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "<title>Swagger UI</title>")
+
+	// Test: /swagger/ should also return index.html
+	wSlash := performRequest(http.MethodGet, "/swagger/", router)
+	assert.Equal(t, http.StatusOK, wSlash.Code)
+	assert.Contains(t, wSlash.Body.String(), "<title>Swagger UI</title>")
 }
 
 func TestDisablingWrapHandler(t *testing.T) {


### PR DESCRIPTION
Describe the PR

Fixes the issue where accessing /swagger and /swagger/ returned 404. Now, both paths return the content of index.html directly, matching typical static web server behavior and improving UX.

Closes #323

Additional context:
- Both /swagger and /swagger/ now return the Swagger UI directly instead of 404.
- Added tests for both paths to ensure future compatibility, in case gin's routing behavior changes.
- For local testing, please update `example/basic/main.go` as follows to ensure Swagger UI loads the API definition correctly:

```diff
- url := ginSwagger.URL("http://petstore.swagger.io:8080/swagger/doc.json") // The url pointing to API definition
+ url := ginSwagger.URL("/swagger/doc.json") // The url pointing to API definition
```

- Please check the behavior by accessing both /swagger and /swagger/ after applying this PR.
